### PR TITLE
DOC: add video tutorial link

### DIFF
--- a/docs/source/example-walk-through/video_tutorial.rst
+++ b/docs/source/example-walk-through/video_tutorial.rst
@@ -1,0 +1,7 @@
+**************
+Video Tutorial
+**************
+
+
+See Tutorial: `Edm to PyDM Walk-Through Example <https://drive.google.com/file/d/1djZSqWS6bK6ZA4rK0KApiNpd0cFIuZ7I/view?usp=sharing/>`_.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ tasks, and data plugins for multiple control systems.
     example-walk-through/start_with_qdesigner.rst
     example-walk-through/convert_existing_edm.rst
     example-walk-through/stylesheets.rst
+    example-walk-through/video_tutorial.rst
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Closes #19  - although we might want to add the video to confluence page instead of google drive.... ??
I'd like more opinions here....

The problem is that if we place it here and people outside SLAC will access it, then they won't be able to get the link working for them, and it will look like a broken link I think ( i could be wrong)